### PR TITLE
Added unit test for markdown_to_html function

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -37,8 +37,6 @@ def pytest_configure():
     pytest.simple_md_with_code_contents = 'Hello\n' \
         '**Bold**\n' \
         '__Another Bold__\n' \
-        '*Italics*\n' \
-        '_More Italics_\n' \
         '`some code`\n' \
         '```\n' \
         'some multiline code\n' \
@@ -104,8 +102,6 @@ def pytest_configure():
         '<p>Hello</p>\n' \
         '<p><strong>Bold</strong></p>\n' \
         '<p><strong>Another Bold</strong></p>\n' \
-        '<p>*Italics*</p>\n' \
-        '<p>_More Italics_</p>\n' \
         '<p><code>some code</code></p>\n' \
         '<pre>\n' \
         'some multiline code\n' \

--- a/conftest.py
+++ b/conftest.py
@@ -91,6 +91,24 @@ def pytest_configure():
         '</body>\n' \
         '</html>'
 
+    pytest.simple_html_with_code_from_md = '<!doctype html>\n' \
+        '<html lang="en">\n' \
+        '<head>\n' \
+        '\t<meta charset="utf-8">\n' \
+        '\t<title>markdown</title>\n' \
+        '\t<meta name="viewport" content="width=device-width, initial-scale=1" />\n' \
+        '</head>\n' \
+        '<body>\n' \
+        '<p>Hello><p>\n' \
+        '<p><strong>Bold</strong></p>\n' \
+        '<p><strong>Another Bold</strong></p>\n' \
+        '<p><em>Italics</em></p>\n' \
+        '<p><em>More Italics</em></p>\n' \
+        '<p><code>some code</code></p>\n' \
+        '<p><pre>some multiline code</pre></p>\n' \
+        '</body>\n' \
+        '</html>'
+
     pytest.html_from_frontmatter_md = '<!doctype html>\n' \
         '<html lang="en">\n' \
         '<head>\n' \

--- a/conftest.py
+++ b/conftest.py
@@ -34,6 +34,14 @@ def pytest_configure():
         '**Bold**\n' \
         '*Italics*\n'
 
+    pytest.simple_md_with_code_contents = 'Hello\n' \
+        '**Bold**\n' \
+        '__Another Bold__\n' \
+        '*Italics*\n' \
+        '_More Italics_\n' \
+        '`some code`\n' \
+        '```some multiline code```\n'
+
     pytest.frontmatter_md_contents = '---\n' \
         'title: My First Blog\n' \
         'lang: en\n' \

--- a/conftest.py
+++ b/conftest.py
@@ -40,7 +40,9 @@ def pytest_configure():
         '*Italics*\n' \
         '_More Italics_\n' \
         '`some code`\n' \
-        '```some multiline code```\n'
+        '```\n' \
+        'some multiline code\n' \
+        '```\n'
 
     pytest.frontmatter_md_contents = '---\n' \
         'title: My First Blog\n' \
@@ -95,17 +97,19 @@ def pytest_configure():
         '<html lang="en">\n' \
         '<head>\n' \
         '\t<meta charset="utf-8">\n' \
-        '\t<title>markdown</title>\n' \
+        '\t<title>markdownWithCode</title>\n' \
         '\t<meta name="viewport" content="width=device-width, initial-scale=1" />\n' \
         '</head>\n' \
         '<body>\n' \
-        '<p>Hello><p>\n' \
+        '<p>Hello</p>\n' \
         '<p><strong>Bold</strong></p>\n' \
         '<p><strong>Another Bold</strong></p>\n' \
-        '<p><em>Italics</em></p>\n' \
-        '<p><em>More Italics</em></p>\n' \
+        '<p>*Italics*</p>\n' \
+        '<p>_More Italics_</p>\n' \
         '<p><code>some code</code></p>\n' \
-        '<p><pre>some multiline code</pre></p>\n' \
+        '<pre>\n' \
+        'some multiline code\n' \
+        '</pre>\n' \
         '</body>\n' \
         '</html>'
 

--- a/tests/convert_test.py
+++ b/tests/convert_test.py
@@ -106,7 +106,7 @@ def test_main_md_frontmatter(tmpdir, helpers):
 
 
 def test_markdown_to_html(tmpdir, helpers):
-    """Tests convert.py markdown_to_html function for bolding, italics, code blocks and fenced codeblocks"""
+    """Tests convert.py markdown_to_html function for bolding, code blocks and fenced codeblocks"""
     # Pass command line arguments to main() to mimic following command line program call:
     # python src/convert -o <tmp_output_dir> <tmp_input_file>
     arguments = c.parse_args(

--- a/tests/convert_test.py
+++ b/tests/convert_test.py
@@ -107,12 +107,9 @@ def test_main_md_frontmatter(tmpdir, helpers):
 
 def test_markdown_to_html(tmpdir, helpers):
     """Tests convert.py markdown_to_html function for bolding, code blocks and fenced codeblocks"""
-    # Pass command line arguments to main() to mimic following command line program call:
-    # python src/convert -o <tmp_output_dir> <tmp_input_file>
-    arguments = c.parse_args(
-        ["-o", str(tmpdir), helpers.new_file(tmpdir, "markdownWithCode.md", pytest.simple_md_with_code_contents)])
-    # Run main function
-    c.main(arguments)
+    # Run markdown_to_html function
+    c.markdown_to_html(helpers.new_file(tmpdir, "markdownWithCode.md", pytest.simple_md_with_code_contents),tmpdir, '')
+
     # Compare actual output file content to expected
     output_path = tmpdir.join('markdownWithCode.html')
     assert helpers.file_contents(output_path) == pytest.simple_html_with_code_from_md

--- a/tests/convert_test.py
+++ b/tests/convert_test.py
@@ -103,3 +103,16 @@ def test_main_md_frontmatter(tmpdir, helpers):
     output_path = tmpdir.join('frontmatter.html')
     assert helpers.file_contents(
         output_path) == pytest.html_from_frontmatter_md
+
+
+def test_markdown_to_html(tmpdir, helpers):
+    """Tests convert.py markdown_to_html function for bolding, italics, code blocks and fenced codeblocks"""
+    # Pass command line arguments to main() to mimic following command line program call:
+    # python src/convert -o <tmp_output_dir> <tmp_input_file>
+    arguments = c.parse_args(
+        ["-o", str(tmpdir), helpers.new_file(tmpdir, "markdownWithCode.md", pytest.simple_md_with_code_contents)])
+    # Run main function
+    c.main(arguments)
+    # Compare actual output file content to expected
+    output_path = tmpdir.join('markdownWithCode.html')
+    assert helpers.file_contents(output_path) == pytest.simple_html_with_code_from_md

--- a/tests/convert_test.py
+++ b/tests/convert_test.py
@@ -108,7 +108,10 @@ def test_main_md_frontmatter(tmpdir, helpers):
 def test_markdown_to_html(tmpdir, helpers):
     """Tests convert.py markdown_to_html function for bolding, code blocks and fenced codeblocks"""
     # Run markdown_to_html function
-    c.markdown_to_html(helpers.new_file(tmpdir, "markdownWithCode.md", pytest.simple_md_with_code_contents), tmpdir, '')
+    c.markdown_to_html(helpers.new_file(
+        tmpdir,
+        "markdownWithCode.md",
+        pytest.simple_md_with_code_contents), tmpdir, '')
 
     # Compare actual output file content to expected
     output_path = tmpdir.join('markdownWithCode.html')

--- a/tests/convert_test.py
+++ b/tests/convert_test.py
@@ -108,7 +108,7 @@ def test_main_md_frontmatter(tmpdir, helpers):
 def test_markdown_to_html(tmpdir, helpers):
     """Tests convert.py markdown_to_html function for bolding, code blocks and fenced codeblocks"""
     # Run markdown_to_html function
-    c.markdown_to_html(helpers.new_file(tmpdir, "markdownWithCode.md", pytest.simple_md_with_code_contents),tmpdir, '')
+    c.markdown_to_html(helpers.new_file(tmpdir, "markdownWithCode.md", pytest.simple_md_with_code_contents), tmpdir, '')
 
     # Compare actual output file content to expected
     output_path = tmpdir.join('markdownWithCode.html')


### PR DESCRIPTION
This fixes #24

Added a unit test for `markdown_to_html` that tests the following:
```
# Replace **bold** and __bold__ with <strong>bold</strong>
# Replace `text` with <code>text</code>
# Replace multi-line code blocks that are inside ```...``` with <pre>...</pre>
```
Testing italics conversion was originally discussed in the above Issue, but a bug was discovered in which Markdown Italics would not be converted. After discussing with author, italics conversion tests were removed.

Change Summary
---
`conftest.py`
- added `simple_md_with_code_contents` global variable
- added `simple_html_with_code_from_md` global variable
`tests/convert_test.py`
- added `test_markdown_to_html` unit test
